### PR TITLE
fix error when run revolver pipeline

### DIFF
--- a/R/remove_patients.R
+++ b/R/remove_patients.R
@@ -46,9 +46,8 @@ remove_patients = function(x,
 
   if(length(drv_to_cancel) > 0) {
     message(paste(drv_to_cancel, collapse = ', '), ": driver events that now are found in only one patient, will be now removed ...")
+    x = remove_drivers(x, drv_to_cancel, check = FALSE)
   }
-
-   x = remove_drivers(x, drv_to_cancel, check = FALSE)
 
   # if has clusters, force to recompute
   if(has_clusters(x)) {

--- a/R/revolver_cluster.R
+++ b/R/revolver_cluster.R
@@ -83,11 +83,12 @@ revolver_cluster = function(
       if (pb.status) pb$tick()$print()
       
       # Both patient have a transfer that we take and augment with E
-      p1_IT = ITransfer(x, patients[p1], data = 'fits', type = 'drivers') %>%
-        left_join(E, by = c('from', 'to'))
+      p1_IT = ITransfer(x, patients[p1], data = 'fits', type = 'drivers')
+      if (!is.null(p1_IT)) p1_IT <- left_join(p1_IT, E, by = c('from', 'to'))
       
-      p2_IT = ITransfer(x, patients[p2], data = 'fits', type = 'drivers') %>%
-        left_join(E, by = c('from', 'to'))
+      p2_IT = ITransfer(x, patients[p2], data = 'fits', type = 'drivers') 
+      if (!is.null(p2_IT)) p2_IT <- left_join(p2_IT, E, by = c('from', 'to'))
+        
       
       # The distance is the absolute value of non-shared edges
       distances[patients[p1], patients[p2]] = bind_rows(p1_IT, p2_IT) %>%


### PR DESCRIPTION
for `remove_patients` function:
when `drv_to_cancel` has no items, it will incur error for `remove_drivers` function

for `revolver_cluster` function:
`left_join` won't join `NULL` argument and incur error 